### PR TITLE
Fix icon container overflow and padding

### DIFF
--- a/css/index-todo.css
+++ b/css/index-todo.css
@@ -417,7 +417,8 @@ p {
     justify-content: center;
     margin: 0 auto 25px;
     transition: all 0.3s ease;
-    padding: 10px;
+    overflow: hidden;
+    padding: 0;
 }
 
 .section-icon {


### PR DESCRIPTION
## Summary
- Add overflow:hidden and remove padding from `.icon-container` to clip overflow and eliminate white border

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7976639c832897d3be8bf61423bd